### PR TITLE
hyperlink and wording fix

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,46 @@
+# Contributing Guidelines
+
+## How to contribute
+
+If you would like to contribute to this project, go here for more information:
+
+* [Splunk and open source][contributions]
+* [Individual contributions][indivcontrib]
+* [Company contributions][companycontrib]
+
+## Issues & Bug Reports
+
+If you're seeing some unexpected behavior with this project, please create an [issue on GitHub][issues] with the following information:
+
+0. Version of this project you're using (ex: 1.3.1)
+0. Platform version (ex: Windows Server 2012)
+0. Framework version (ex: Python 2.7.8)
+0. Splunk version (ex: 6.2.2)
+0. Other relevant information (ex: local/remote environment, Splunk network configuration)
+
+Alternatively, if you have a Splunk question please ask on [Splunk Answers][answers]
+
+## Pull requests
+
+We love to see pull requests!
+
+To create a pull request:
+
+0. Fill out the [Individual Contributor Agreement][indivcontrib].
+0. Fork [the repository][repo].
+0. Make changes to the **`develop`** branch, preferably with tests.
+0. Create a [pull request][pulls] against the **`develop`** branch.
+
+## Contact us
+
+You can reach Splunk support at _support@splunk.com_ if you have Splunk related questions.
+
+You can reach the Developer Platform team at _devinfo@splunk.com_.
+
+[contributions]:            http://dev.splunk.com/view/opensource/SP-CAAAEDM
+[indivcontrib]:             http://dev.splunk.com/goto/individualcontributions
+[companycontrib]:           http://dev.splunk.com/view/companycontributions/SP-CAAAEDR
+[answers]:                  http://answers.splunk.com/
+[repo]:                     https://github.com/splunk/splunk-sdk-python
+[issues]:                   https://github.com/splunk/splunk-sdk-python/issues
+[pulls]:                    https://github.com/splunk/splunk-sdk-python/pulls

--- a/examples/analytics/README.md
+++ b/examples/analytics/README.md
@@ -73,7 +73,7 @@ Similarly to `AnalyticsTracker`, the `output.py` file defines the "output" side
 of the Analytics service. If you want to extract the events you logged in using
 `AnalyticsTracker`, you'd use the `AnalyticsRetriever` class.
 
-Creating an `AnalyticsTracker` instance is identical to the `AnalyticsTracker`:
+Creating an `AnalyticsRetriever` instance is identical to the `AnalyticsTracker`:
 
 ```python
 from analytics.output import AnalyticsRetriever
@@ -138,7 +138,7 @@ you can see a graph of events over time, properties, etc.
 
 We make use of the excellent open source
 [flot](http://code.google.com/p/flot/) graphing library to render
-our Javascript graphs. We also use the [`bottle.py`](bottlepy.org)
+our Javascript graphs. We also use the [`bottle.py`](http://bottlepy.org)
 micro-web framework.
 
 ## Running the Sample


### PR DESCRIPTION
Changed AnalyticsTracker to AnalyticsRetriever, since that is what the topic was discussing.
Fixed the bottle.py hyperlink, since it was trying to link relative instead of the bottlepy.org webpage.
